### PR TITLE
Fix imports according to PEP8

### DIFF
--- a/ota_suit_server/__main__.py
+++ b/ota_suit_server/__main__.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python
+import asyncio
+import hashlib
+import logging
+from pathlib import Path
+import os.path
 
 from aiohttp import web
 import aiohttp_jinja2
@@ -9,14 +13,7 @@ import aiocoap
 from . import routes
 from . import resources
 
-import asyncio
-import hashlib
-import logging
-from pathlib import Path
-import os.path
-
 PROJECT_ROOT = '.'
-
 
 def get_files():
     p = Path('./uploads')

--- a/ota_suit_server/gen_manifest.py
+++ b/ota_suit_server/gen_manifest.py
@@ -1,16 +1,14 @@
-#!/usr/bin/env python
-
 import argparse
 import base64
 import binascii
 import calendar
-import cbor
 import hashlib
 import os
 import os.path
 import time
 import uuid
 
+import cbor
 import ed25519
 from pyasn1.type import univ
 from pyasn1.type.namedtype import NamedType, NamedTypes

--- a/ota_suit_server/resources.py
+++ b/ota_suit_server/resources.py
@@ -1,10 +1,11 @@
-import aiocoap
-import aiocoap.resource as resource
+
 from collections import namedtuple
 import hashlib
 import os.path
 from pathlib import Path
 
+import aiocoap
+import aiocoap.resource as resource
 
 def check_exists(uploads, name, digest):
     for upload in uploads:

--- a/ota_suit_server/routes.py
+++ b/ota_suit_server/routes.py
@@ -1,8 +1,8 @@
-from . import views
-from . import gen_manifest
 
 import os.path
 
+from . import views
+from . import gen_manifest
 
 def setup_routes(app, root):
     app.router.add_get('/', views.index)

--- a/ota_suit_server/views.py
+++ b/ota_suit_server/views.py
@@ -1,12 +1,12 @@
-from . import resources
+
+import logging
 
 from aiohttp import web
 import aiocoap
 import aiohttp_jinja2
 from multidict import MultiDict
 
-import logging
-
+from . import resources
 
 async def index(request):
     text = """


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0008/:

> 
> Imports should be grouped in the following order:
> 
>     Standard library imports.
>     Related third party imports.
>     Local application/library specific imports.
> 
> You should put a blank line between each group of imports.